### PR TITLE
Auto-run migrations and create default admin user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+RUN chmod +x entrypoint.sh
 
 EXPOSE 8000
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+python manage.py migrate --noinput
+
+python manage.py shell <<'PYTHON'
+from django.contrib.auth import get_user_model
+User = get_user_model()
+if not User.objects.filter(username='admin').exists():
+    User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+PYTHON
+
+exec "$@"


### PR DESCRIPTION
## Summary
- run migrations and create an admin user on container startup
- add entrypoint script and wire it through Dockerfile

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_689dc4657d6c83228a7ca4d023bf0e41