### PR TITLE
Expose authentication errors in login and signup forms

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -14,12 +14,23 @@
 
         <form method="post" action="{% url 'account_login' %}">
           {% csrf_token %}
-          
+
+          {% if form.non_field_errors %}
+          <div class="alert alert-danger" role="alert">
+            {% for error in form.non_field_errors %}
+            {{ error }}
+            {% endfor %}
+          </div>
+          {% endif %}
+
           <div class="mb-3">
             <label class="form-label fw-semibold">
               <i class="fas fa-envelope me-1"></i>Email
             </label>
             {{ form.login }}
+            {% for error in form.login.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
           </div>
 
           <div class="mb-3">
@@ -27,6 +38,9 @@
               <i class="fas fa-lock me-1"></i>Password
             </label>
             {{ form.password }}
+            {% for error in form.password.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
           </div>
 
           {% if form.remember %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -14,12 +14,23 @@
 
         <form method="post" action="{% url 'account_signup' %}">
           {% csrf_token %}
-          
+
+          {% if form.non_field_errors %}
+          <div class="alert alert-danger" role="alert">
+            {% for error in form.non_field_errors %}
+            {{ error }}
+            {% endfor %}
+          </div>
+          {% endif %}
+
           <div class="mb-3">
             <label class="form-label fw-semibold">
               <i class="fas fa-envelope me-1"></i>Email
             </label>
             {{ form.email }}
+            {% for error in form.email.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
           </div>
 
           <div class="mb-3">
@@ -27,6 +38,9 @@
               <i class="fas fa-lock me-1"></i>Password
             </label>
             {{ form.password1 }}
+            {% for error in form.password1.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
           </div>
 
           <div class="mb-3">
@@ -34,6 +48,9 @@
               <i class="fas fa-lock me-1"></i>Confirm Password
             </label>
             {{ form.password2 }}
+            {% for error in form.password2.errors %}
+            <div class="text-danger small">{{ error }}</div>
+            {% endfor %}
           </div>
 
           <div class="d-grid mb-3">

--- a/templates/base.html
+++ b/templates/base.html
@@ -177,6 +177,14 @@
 </nav>
 <div style="padding-top: 100px;">
   <div class="container">
+    {% if messages %}
+    {% for message in messages %}
+    <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+      {{ message }}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endfor %}
+    {% endif %}
     {% block content %}{% endblock %}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- surface non-field and field validation errors on login and signup
- show Django message framework alerts in base template

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_689dcd50879083229e97a626242f34af